### PR TITLE
Allow parsing of source "A" images

### DIFF
--- a/Model/IPSImage.h
+++ b/Model/IPSImage.h
@@ -17,6 +17,8 @@
 
 @interface IPSImage : NSObject <IPSObjectProtocol>
 
+	@property (readonly,copy) NSString * source;
+
     @property (readonly,copy) NSString * name;
 
     @property (readonly,copy) NSString * bundleIdentifier;

--- a/Model/IPSImage.m
+++ b/Model/IPSImage.m
@@ -13,6 +13,8 @@
 
 #import "IPSImage.h"
 
+NSString * const IPSImageSopurceKey=@"source";
+
 NSString * const IPSImageArchitectureKey=@"arch";
 
 NSString * const IPSImageNameKey=@"name";
@@ -32,6 +34,8 @@ NSString * const IPSImageBaseAddressKey=@"base";
 NSString * const IPSImageSizeKey=@"size";
 
 @interface IPSImage ()
+
+	@property (readwrite,copy) NSString * source;
 
     @property (readwrite,copy) NSString * name;
 
@@ -77,11 +81,20 @@ NSString * const IPSImageSizeKey=@"size";
     
     if (self!=nil)
     {
-        NSString * tString=inRepresentation[IPSImageNameKey];
+		NSString * tString=inRepresentation[IPSImageSopurceKey];
+		
+		IPSFullCheckStringValueForKey(tString,IPSImageSopurceKey);
+			
+		_source=[tString copy];
+		
+		tString=inRepresentation[IPSImageNameKey];
         
-        IPSFullCheckStringValueForKey(tString,IPSImageNameKey);
-        
-        _name=[tString copy];
+		if (tString!=nil)
+		{
+			IPSFullCheckStringValueForKey(tString,IPSImageNameKey);
+			
+			_name=[tString copy];
+		}
         
         tString=inRepresentation[IPSImageBundleVersion];
         
@@ -112,9 +125,12 @@ NSString * const IPSImageSizeKey=@"size";
         
         tString=inRepresentation[IPSImagePathKey];
         
-        IPSFullCheckStringValueForKey(tString,IPSImagePathKey);
-        
-        _path=[tString copy];
+		if (tString!=nil)
+		{
+			IPSFullCheckStringValueForKey(tString,IPSImagePathKey);
+			
+			_path=[tString copy];
+		}
         
         tString=inRepresentation[IPSImageUUIDKey];
         
@@ -122,6 +138,15 @@ NSString * const IPSImageSizeKey=@"size";
         
         _UUID=[[NSUUID alloc] initWithUUIDString:tString];
         
+		tString=inRepresentation[IPSImageArchitectureKey];
+		
+		if (tString!=nil)
+		{
+			IPSFullCheckStringValueForKey(tString,IPSImageArchitectureKey);
+		
+			_architecture=[tString copy];
+		}
+		
         NSNumber * tNumber=inRepresentation[IPSImageBaseAddressKey];
         
         IPSFullCheckNumberValueForKey(tNumber,IPSImageBaseAddressKey);


### PR DESCRIPTION
Many of the crash reports I have include an image object from source "A":

``` json
  "usedImages" : [
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 140703613407232,
    "size" : 225280,
    "uuid" : "12bd6f13-c452-35ee-9069-51befef29f1a",
    "path" : "\/usr\/lib\/system\/libsystem_kernel.dylib",
    "name" : "libsystem_kernel.dylib"
  },
  ...
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 140703613632512,
    "size" : 49152,
    "uuid" : "29a2750e-f31b-3630-8761-242a6bc3e99e",
    "path" : "\/usr\/lib\/system\/libsystem_pthread.dylib",
    "name" : "libsystem_pthread.dylib"
  },
  {
    "size" : 0,
    "source" : "A",
    "base" : 0,
    "uuid" : "00000000-0000-0000-0000-000000000000"
  }
],
```

These image records have no `name`, `arch`, or `path` properties and are typically zero sized.

The problem is, the code that builds the array of images objects will fail if any image object can't be parsed, leaving a `nil` array of images. The result is that *none* of the stack frame symbols get translated properly.

My solution was to simply allow for this kind of image.

While I was in there, I also added a `source` property and implemented the code to parse the `architecture` property (which was defined, but wasn't being read).