### PR TITLE
Introduce thread name support

### DIFF
--- a/Model/IPSThread.h
+++ b/Model/IPSThread.h
@@ -27,6 +27,8 @@
 
     @property (readonly) NSUInteger ID;
 
+    @property (readonly,copy) NSString * name;     // can be nil
+
     @property (readonly) NSArray<IPSThreadFrame *> * frames;
 
     @property (readonly) BOOL triggered;

--- a/Model/IPSThread.m
+++ b/Model/IPSThread.m
@@ -17,6 +17,8 @@
 
 NSString * const IPSThreadIDKey=@"id";
 
+NSString * const IPSThreadNameKey=@"name";
+
 NSString * const IPSThreadQueueKey=@"queue";
 
 NSString * const IPSThreadFramesKey=@"frames";
@@ -32,6 +34,8 @@ NSString * const IPSThreadInstructionStateKey=@"instructionState";
     @property (readwrite,copy) NSString * queue;     // can be nil
 
     @property (readwrite) NSUInteger ID;
+
+    @property (readwrite,copy) NSString * name;     // can be nil
 
     @property (readwrite) NSArray<IPSThreadFrame *> * frames;
 
@@ -76,7 +80,16 @@ NSString * const IPSThreadInstructionStateKey=@"instructionState";
             _ID=[tNumber unsignedIntegerValue];
         }
         
-        NSString * tString=inRepresentation[IPSThreadQueueKey];
+        NSString * tString=inRepresentation[IPSThreadNameKey];
+        
+        if (tString!=nil)
+        {
+            IPSClassCheckStringValueForKey(tString,IPSThreadNameKey);
+            
+            _name=[tString copy];
+        }
+
+        tString=inRepresentation[IPSThreadQueueKey];
         
         if (tString!=nil)
         {
@@ -141,6 +154,9 @@ NSString * const IPSThreadInstructionStateKey=@"instructionState";
     NSMutableDictionary * tMutableDictionary=[NSMutableDictionary dictionary];
     
     tMutableDictionary[IPSThreadIDKey]=@(self.ID);
+    
+    if (self.name!=nil)
+        tMutableDictionary[IPSThreadNameKey]=self.name;
     
     if (self.queue!=nil)
         tMutableDictionary[IPSThreadQueueKey]=self.queue;

--- a/tool_ips2crash/ips2crash/IPSReport+CrashRepresentation.m
+++ b/tool_ips2crash/ips2crash/IPSReport+CrashRepresentation.m
@@ -297,9 +297,11 @@
         
         NSString * tCrashedString=(bThread.triggered==YES) ? @" Crashed":@"";
         
+        NSString * tNameString=(bThread.name!=nil) ? [NSString stringWithFormat:@" %@",bThread.name] : @"";
+
         NSString * tDispatchQueueString=(bThread.queue!=nil) ? [NSString stringWithFormat:@": Dispatch queue: %@",bThread.queue] : @"";
         
-        [tMutableString appendFormat:@"Thread %lu%@:%@\n",(unsigned long)bThreadIndex,tCrashedString,tDispatchQueueString];
+        [tMutableString appendFormat:@"Thread %lu%@:%@%@\n",(unsigned long)bThreadIndex,tCrashedString, tNameString, tDispatchQueueString];
         
         [bThread.frames enumerateObjectsUsingBlock:^(IPSThreadFrame * bFrame, NSUInteger bFrameIndex, BOOL * _Nonnull stop) {
             


### PR DESCRIPTION
Thank you for this great tool !

Would you please consider this trivial pull request, in order to get thread names in resulting .crash files as in the good old days... 

When available, it just extracts thread name from .ips file and add it to the thread ID line in the .crash file.

Definitely helpful in multi threaded debugging scenarios.